### PR TITLE
Use --keep-going to build all packages even if there are build failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - uses: cachix/install-nix-action@v13
       - uses: cachix/cachix-action@v10
         with:
@@ -21,4 +21,4 @@ jobs:
           # If you chose API tokens for write access OR if you have a private cache
           authToken: '${{ secrets.NIX_DATA_CACHIX_AUTH_TOKEN }}'
       - name: build
-        run: nix-build --show-trace jobsets/${{ matrix.jobset }}.nix
+        run: nix-build --show-trace --keep-going jobsets/${{ matrix.jobset }}.nix


### PR DESCRIPTION
cc @tbenst 