### PR TITLE
Add the Matrix channel address to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Currently, the repository targets the Python & R ecosystem, and builds against I
 
 ## Get in touch
 
-Join the [nix-data Slack workspace](https://join.slack.com/t/nix-data/shared_invite/zt-ca8csgcz-N9Fyh~tnoZPY8x5lE_slFA).
+- [Matrix chat](https://matrix.to/#/#datascience:nixos.org) at `#datascience:nixos.org`
+- [Slack workspace](https://join.slack.com/t/nix-data/shared_invite/zt-ca8csgcz-N9Fyh~tnoZPY8x5lE_slFA)
 
 ## Repo format
 See https://www.reddit.com/r/NixOS/comments/8tkllx/standard_project_structure/ for more info.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Currently, the repository targets the Python & R ecosystem, and builds against I
 ## Get in touch
 
 - [Matrix chat](https://matrix.to/#/#datascience:nixos.org) at `#datascience:nixos.org`
+- [Discord](https://discord.gg/wXZDqVYgjZ) at #data-science
 - [Slack workspace](https://join.slack.com/t/nix-data/shared_invite/zt-ca8csgcz-N9Fyh~tnoZPY8x5lE_slFA)
 
 ## Repo format


### PR DESCRIPTION
Hope there's no objection for matrix preceding slack:) There was also, in `#general`, a mention of some discord room, but I don't know where it is